### PR TITLE
fix: 절약 금액 +/- 부호 및 텍스트 반전 버그 수정

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-02-26
+
+### Fixed
+- 결과 페이지 절약 금액 +/- 부호 및 텍스트 반전 버그 수정 (토스: 텍스트 반대, 웹: 부호 반대)
+
 ## [1.0.0] - 2026-02-25
 
 ### Released

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -320,9 +320,9 @@ function Result() {
             </Text>
             <Text display="block" color={adaptive.grey500} typography="t7" fontWeight="regular">
               {savedTotal > 0
-                ? "현지에서 사는 것이 더 저렴해요"
+                ? "한국에서 사는 것이 더 저렴해요"
                 : savedTotal < 0
-                  ? "한국에서 사는 것이 더 저렴해요"
+                  ? "현지에서 사는 것이 더 저렴해요"
                   : "한국과 현지 가격이 동일해요"}
             </Text>
           </div>
@@ -513,7 +513,7 @@ function Result() {
           textAlign: "center",
         }}>
           <div style={{ fontSize: 14, color: "var(--muted)", marginBottom: 4 }}>
-            {(savedTotal > 0 ? "−" : savedTotal < 0 ? "+" : "−") + " 총 절약"}
+            {(savedTotal > 0 ? "+" : savedTotal < 0 ? "−" : "") + " 총 절약"}
           </div>
           <div style={{
             fontSize: 28, fontWeight: 800,


### PR DESCRIPTION
## Summary
- 토스 환경: 절약 텍스트("현지에서/한국에서 사는 것이 더 저렴해요")가 반대로 표시되던 버그 수정
- 웹 환경: 절약 금액 앞 +/- 부호가 반대로 표시되던 버그 수정

## Changes
- `Result.tsx` 토스 환경 텍스트 조건 수정 (lines 322-325)
- `Result.tsx` 웹 환경 부호 조건 수정 (line 516)
- `CHANGELOG.md` v1.0.1 항목 추가

## Test plan
- [ ] 토스 시뮬레이터에서 한국이 더 싼 경우 "한국에서 사는 것이 더 저렴해요" 표시 확인
- [ ] 토스 시뮬레이터에서 현지가 더 싼 경우 "현지에서 사는 것이 더 저렴해요" 표시 확인
- [ ] 웹에서 한국이 더 싼 경우 "+" 부호 확인
- [ ] 웹에서 현지가 더 싼 경우 "−" 부호 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)