### PR TITLE
improve: 로딩 스피너 및 상태 텍스트 사이즈 키우기

### DIFF
--- a/src/pages/Analyzing.tsx
+++ b/src/pages/Analyzing.tsx
@@ -185,9 +185,11 @@ function Analyzing() {
             </>
           ) : (
             <>
-              <Loader size="large" />
+              <div style={{ transform: "scale(1.4)", marginBottom: 8 }}>
+                <Loader size="large" />
+              </div>
               <div style={{ textAlign: "center" }}>
-                <div style={{ fontSize: 14, color: "#8B95A1", lineHeight: 1.6 }}>
+                <div style={{ fontSize: 16, color: "#8B95A1", lineHeight: 1.6 }}>
                   {statusText}
                 </div>
               </div>
@@ -325,8 +327,8 @@ function Analyzing() {
           <>
             <div
               style={{
-                width: 80,
-                height: 80,
+                width: 100,
+                height: 100,
                 borderRadius: "50%",
                 backgroundColor: "var(--card)",
                 border: "2px solid var(--border)",
@@ -347,15 +349,15 @@ function Analyzing() {
                   animation: "spin 1.2s linear infinite",
                 }}
               />
-              <span style={{ fontSize: 32 }}>🔍</span>
+              <span style={{ fontSize: 38 }}>🔍</span>
             </div>
             <div style={{ textAlign: "center" }}>
               <div
-                style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}
+                style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}
               >
                 AI가 상품을 분석하고 있습니다
               </div>
-              <div style={{ fontSize: 14, color: "var(--muted)" }}>
+              <div style={{ fontSize: 16, color: "var(--muted)" }}>
                 {statusText}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- 토스: TDS Loader를 1.4배 스케일, 상태 텍스트 14→16px
- 웹: 스피너 원 80→100px, 이모지 32→38, 제목 18→20px, 텍스트 14→16px

## Test plan
- [ ] 토스 시뮬레이터에서 로딩 화면 스피너/텍스트 크기 확인
- [ ] 웹에서 로딩 화면 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)